### PR TITLE
Reorder Introduction articles

### DIFF
--- a/content/introduction/_meta.js
+++ b/content/introduction/_meta.js
@@ -1,8 +1,8 @@
 export default {
-  "getting-started-with-web-template": {},
-  "development-skills": {},
-  "introduction-to-customizing": {},
-  "introducing-template": {},
-  "getting-started-with-sharetribe-cli": {},
-  "getting-started-with-integration-api": {},
+  'introduction-to-customizing': {},
+  'introducing-template': {},
+  'getting-started-with-web-template': {},
+  'development-skills': {},
+  'getting-started-with-sharetribe-cli': {},
+  'getting-started-with-integration-api': {},
 };

--- a/content/introduction/development-skills/index.mdx
+++ b/content/introduction/development-skills/index.mdx
@@ -1,13 +1,14 @@
 ---
-title: What development skills are needed?
-sidebarTitle: Development skills
+title:
+  What development skills are needed with the Sharetribe Web Template?
+sidebarTitle: Development skills with the Sharetribe Web Template
 description:
   Building a custom marketplace with Sharetribe Developer Platform
   requires some software development skills. This article explains what
   you need to know when customizing the platform.
 ---
 
-# What development skills are needed?
+# What development skills are needed with the Sharetribe Web Template?
 
 You can use any technology to build a marketplace on top of the
 [Marketplace API](/introduction/#the-marketplace-api). However, making a


### PR DESCRIPTION
- Reorder the articles to make it easier for folks to first find the high-level information
- Rename Development skills article to specifically reference the template for clarity – that way, we can group all template focused articles together, and non-template developers know they don't need to read them