### PR TITLE
Update mentions of CRA after eject

### DIFF
--- a/content/introduction/development-skills/index.mdx
+++ b/content/introduction/development-skills/index.mdx
@@ -54,17 +54,18 @@ template with code will likely require skills with the following tools:
 ## Development tooling
 
 While the Sharetribe Web Template uses Webpack, PostCSS, and various
-other tools behind the scene, knowledge of these technologies is not
-needed in usual customizations. Compared to a usual frontend project
-with a long list of dependencies and extensive Webpack configuration
-files, Sharetribe Web Template hides all this behind a
-[sharetribe-scripts](https://www.npmjs.com/package/sharetribe-scripts)
-NPM package.
+other tools, knowledge of these technologies is not needed in usual
+customizations. Sharetribe Web Template has a default Webpack setup
+(based on the now deprecated
+[Create React App](https://github.com/facebook/create-react-app)
+library) with server-side rendering, code-splitting, and CSS modules
+functionality. In most cases you do not need to make changes to this
+setup.
 
-`sharetribe-scripts` is a fork of the `react-scripts` package in the
-amazing [Create React App](https://github.com/facebook/create-react-app)
-tool. We have added server side rendering and CSS modules, but otherwise
-all the nice things from `create-react-app` are still there.
+The
+[config/README.md file](https://github.com/sharetribe/web-template/tree/main/config/README.md)
+in the template has more information on the webpack setup, in case you
+have a use case for modifying the configurations.
 
 ## Getting help
 

--- a/content/introduction/development-skills/index.mdx
+++ b/content/introduction/development-skills/index.mdx
@@ -64,8 +64,17 @@ setup.
 
 The
 [config/README.md file](https://github.com/sharetribe/web-template/tree/main/config/README.md)
-in the template has more information on the webpack setup, in case you
-have a use case for modifying the configurations.
+in the root directory of the repository has more information on the
+webpack setup, in case you have a use case for modifying the
+configurations. These use cases might include
+
+The configurations defined in the `config/` directory are used in the
+following scripts (defined under the `scripts/` directory):
+
+- `scripts/build.js`
+- `scripts/build-server.js`
+- `scripts/start.js`
+- `scripts/test.js`
 
 ## Getting help
 

--- a/content/template/configuration/template-env/index.mdx
+++ b/content/template/configuration/template-env/index.mdx
@@ -147,12 +147,18 @@ of environment variables.
 
 <Callout>
 
-The template is built on top of Create React App (CRA). CRA uses
-WebpackDevServer for providing Hot Module Reloading feature. In some
-environments, WebpackDevServer might require configuring additional
-environment variables. You should also check
+The Sharetribe Template webpack configuration is based on the now
+deprecated Create React App (CRA). The template uses Webpack's DevServer
+for providing Hot Module Reloading feature. In some environments,
+Webpack DevServer might require configuring additional environment
+variables.
+
+You can also check out
 [CRA's advanced configurations](https://create-react-app.dev/docs/advanced-configuration)
-if you experience problems with socket ports.
+if you experience problems with socket ports. Most of these advanced
+configurations are still used in the template, but it's best to ensure
+by making a codebase search for the specific variable you're wondering
+about.
 
 </Callout>
 

--- a/content/template/configuration/template-env/index.mdx
+++ b/content/template/configuration/template-env/index.mdx
@@ -149,16 +149,17 @@ of environment variables.
 
 The Sharetribe Template webpack configuration is based on the now
 deprecated Create React App (CRA). The template uses Webpack's DevServer
-for providing Hot Module Reloading feature. In some environments,
+for providing a Hot Module Reloading feature. In some environments,
 Webpack DevServer might require configuring additional environment
 variables.
 
 You can also check out
 [CRA's advanced configurations](https://create-react-app.dev/docs/advanced-configuration)
 if you experience problems with socket ports. Most of these advanced
-configurations are still used in the template, but it's best to ensure
-by making a codebase search for the specific variable you're wondering
-about.
+configurations are still used in the template, but if you're wondering
+whether a specific variable is related to your issues, we recommend
+making a codebase search for the variable to see whether it is being
+used in the `/config` or `/scripts` directories.
 
 </Callout>
 

--- a/content/template/introduction/sharetribe-web-template/index.mdx
+++ b/content/template/introduction/sharetribe-web-template/index.mdx
@@ -26,12 +26,13 @@ Access the
 ## Technical overview
 
 The Sharetribe Web Template is a React application built on top of a
-forked version of
-[Create React App (CRA)](https://create-react-app.dev/). The modified
-version of CRA adds support for server-side rendering (SSR) and CSS
-modules. The template also includes a Node.js server, which enables SSR
-and other essential features which require communicating with the
-Sharetribe APIs without allowing the client to modify the requests.
+vendored version of the now deprecated
+[Create React App (CRA)](https://create-react-app.dev/). In addition to
+the basic CRA, the template uses server-side rendering (SSR), code
+splitting, and CSS modules. The template also includes a Node.js server,
+which enables SSR and other essential features which require
+communicating with the Sharetribe APIs without allowing the client to
+modify the requests.
 
 The included Node.js server enables server-side rendering, which helps
 to improve search engine optimization and speed up the application's

--- a/content/template/introduction/sharetribe-web-template/index.mdx
+++ b/content/template/introduction/sharetribe-web-template/index.mdx
@@ -28,11 +28,11 @@ Access the
 The Sharetribe Web Template is a React application built on top of a
 vendored version of the now deprecated
 [Create React App (CRA)](https://create-react-app.dev/). In addition to
-the basic CRA, the template uses server-side rendering (SSR), code
-splitting, and CSS modules. The template also includes a Node.js server,
-which enables SSR and other essential features which require
-communicating with the Sharetribe APIs without allowing the client to
-modify the requests.
+the basic CRA setup, the template uses server-side rendering (SSR) and
+code splitting. The template also includes a Node.js server, which
+enables SSR and other essential features which require communicating
+with the Sharetribe APIs without allowing the client to modify the
+requests.
 
 The included Node.js server enables server-side rendering, which helps
 to improve search engine optimization and speed up the application's


### PR DESCRIPTION
The main documentation assets for the CRA eject are
- a blog post describing relevant changes from the point of view of existing forks
- README.md files in the template's new config directory (entry point: config/README.md and others linked in that file) for developers who are starting with a fresh fork or have already updated their fork to the new setup

