### PR TITLE
Updates to mention the new shortText schema type along side others

### DIFF
--- a/content/concepts/listings/how-the-listing-search-works/index.mdx
+++ b/content/concepts/listings/how-the-listing-search-works/index.mdx
@@ -148,9 +148,10 @@ sdk.listings.query({
 You would then index the attributes by adding a search schema according
 to the data type of the extended data attribute:
 
-- String values can be indexed for keyword search with **schemaType:
-  text**, or for **enum** search, i.e. searching with the attribute name
-  and exact values, using **schemaType: enum**
+- String values can be indexed for keyword search using **schemaType:
+  text** or **schemaType: shortText**, or for enum search, i.e.
+  searching with the attribute name and exact values, using
+  **schemaType: enum**
 - Arrays of strings can be indexed for multi-enum search, i.e. searching
   with the attribute name and exact values, using **schemaType:
   multi-enum**

--- a/content/how-to/listings/extend-listing-data-in-template/index.mdx
+++ b/content/how-to/listings/extend-listing-data-in-template/index.mdx
@@ -138,6 +138,8 @@ determines the shape of the data being saved:
 - **boolean** attributes are saved as **true** or **false** boolean
   values
 - **long** attributes are saved as long i.e. as an 8-byte whole number
+- **shortText** attributes are saved as a single short-text entry e.g. a
+  URL
 - **text** attributes are saved as a single text entry
 
 If the schema type is **enum** or **multi-enum**, you will need to

--- a/content/how-to/transaction-process/add-transaction-fields/index.mdx
+++ b/content/how-to/transaction-process/add-transaction-fields/index.mdx
@@ -128,6 +128,8 @@ saved:
 - **boolean** attributes are saved as **true** or **false** boolean
   values
 - **long** attributes are saved as long i.e. as an 8-byte whole number
+- **shortText** attributes are saved as a single short-text entry e.g. a
+  URL
 - **text** attributes are saved as a single text entry
 - **youtubeVideoUrl** attributes are saved as a single text entry and
   displayed in the Sharetribe Web Template as an embedded Youtube video

--- a/content/how-to/users-and-authentication/extend-user-data-in-template/index.mdx
+++ b/content/how-to/users-and-authentication/extend-user-data-in-template/index.mdx
@@ -111,6 +111,8 @@ user's profile as `protectedData.arrivalInstructions`. The
 - **boolean** attributes are saved as **true** or **false** boolean
   values
 - **long** attributes are saved as long i.e. as an 8-byte whole number
+- **shortText** attributes are saved as a single short-text entry e.g. a
+  URL
 - **text** attributes are saved as a single text entry
 
 If the schema type is **enum** or **multi-enum**, you will need to

--- a/content/template/configuration/variables/index.mdx
+++ b/content/template/configuration/variables/index.mdx
@@ -326,7 +326,7 @@ automatically for **enum**, **multi-enum**, and **long** schema types.
 For schema type **boolean**, you will need to create custom filtering
 options.
 
-Schema type **text** is included in keyword search.
+Schema types **text** and **shortText** are included in keyword search.
 
 </Callout>
 


### PR DESCRIPTION
Modifies mentions of `schemaType` for the upcoming feature that adds support for a new available type: `shortText`