### PR TITLE
Kapa side view

### DIFF
--- a/app/components/KapaWidget.js
+++ b/app/components/KapaWidget.js
@@ -34,6 +34,7 @@ export default function KapaWidget() {
         'Allow tracking and use AI assistant',
       'data-consent-screen-reject-button-text': 'No, thanks',
       'data-search-keyboard-nav-enabled': 'true',
+      'data-view-mode': 'sidebar',
     };
     Object.entries(attrs).forEach(([key, value]) =>
       script.setAttribute(key, value)

--- a/app/components/KapaWidget.js
+++ b/app/components/KapaWidget.js
@@ -35,6 +35,8 @@ export default function KapaWidget() {
       'data-consent-screen-reject-button-text': 'No, thanks',
       'data-search-keyboard-nav-enabled': 'true',
       'data-view-mode': 'sidebar',
+      'data-color-scheme': 'light',
+      'data-color-scheme-selector': '.dark',
     };
     Object.entries(attrs).forEach(([key, value]) =>
       script.setAttribute(key, value)

--- a/app/components/KapaWidget.js
+++ b/app/components/KapaWidget.js
@@ -52,7 +52,8 @@ export default function KapaWidget() {
       const start = Date.now();
       const tryOpen = () => {
         if (typeof window.Kapa?.open === 'function') {
-          window.Kapa.open();
+          const query = params.get('ask');
+          window.Kapa.open(query ? { query } : undefined);
         } else if (Date.now() - start < maxWaitMs) {
           setTimeout(tryOpen, intervalMs);
         }

--- a/app/components/KapaWidget.js
+++ b/app/components/KapaWidget.js
@@ -39,6 +39,26 @@ export default function KapaWidget() {
     Object.entries(attrs).forEach(([key, value]) =>
       script.setAttribute(key, value)
     );
+    script.onload = () => {
+      // Open the widget automatically if the URL contains ?ask.
+      // Intended for support links shared when the team is offline.
+      const params = new URLSearchParams(window.location.search);
+      if (!params.has('ask')) return;
+
+      // Kapa initializes asynchronously after the script loads, so poll
+      // until window.Kapa.open is available.
+      const maxWaitMs = 2000;
+      const intervalMs = 100;
+      const start = Date.now();
+      const tryOpen = () => {
+        if (typeof window.Kapa?.open === 'function') {
+          window.Kapa.open();
+        } else if (Date.now() - start < maxWaitMs) {
+          setTimeout(tryOpen, intervalMs);
+        }
+      };
+      tryOpen();
+    };
     document.head.appendChild(script);
     return () => {
       document.head.removeChild(script);


### PR DESCRIPTION
Moves the Kapa widget so that it opens on the sideview. It also opens the Kapa AI widget automatically when the page is loaded with an `?ask` URL parameter. Handles Kapa's asynchronous initialization by polling until `window.Kapa.open` is available, up to a 2-second timeout.