### PR TITLE
Remove mime type from file resource examples

### DIFF
--- a/content/concepts/files/files-in-sharetribe/index.mdx
+++ b/content/concepts/files/files-in-sharetribe/index.mdx
@@ -47,7 +47,7 @@ messages when using the default Sharetribe Web Template, you'll need to
 double check that files are enabled both through access control and in
 the listing type of the transaction's listing.
 
-## File and FileAttachment
+## file and fileAttachment
 
 In the Sharetribe system, `file` and `fileAttachment` represent two
 different things:

--- a/content/concepts/files/files-in-sharetribe/index.mdx
+++ b/content/concepts/files/files-in-sharetribe/index.mdx
@@ -112,7 +112,6 @@ const messages = await sdk.messages.query({
       "attributes": {
         "name": "File to be uploaded.pdf",
         "state": "available",
-        "mimeType": "application/pdf",
         "size": 10697,
         "deleted": false
       }
@@ -177,7 +176,6 @@ const file = await sdk.files.show({ fileAttachmentId }).data.data;
   "attributes": {
     "name": "File to be uploaded.pdf",
     "state": "available",
-    "mimeType": "application/pdf",
     "size": 10697,
     "deleted": false
   }
@@ -203,7 +201,6 @@ const ownFile = await sdk.ownFiles.show({ id: fileId }).data.data;
   "type": "ownFile",
   "attributes": {
     "name": "File to be uploaded.pdf",
-    "mimeType": "application/pdf",
     "size": 10697,
     "state": "available",
     "createdAt": "2026-05-08T06:53:13.091Z",


### PR DESCRIPTION
The file and ownFile resources were updated to not return the mimeType attribute. Remove the attribute from the resource examples.